### PR TITLE
Updates package versions to avoid installation error.

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,18 +27,18 @@
     "test": ""
   },
   "devDependencies": {
-    "chai": "~1.9.0",
+    "chai": "~3.3.0",
     "grunt": "~0.4.2",
-    "grunt-contrib-jshint": "~0.8.0",
-    "grunt-contrib-watch": "~0.5.3",
-    "grunt-mocha-test": "~0.9.0",
-    "mocha": "~1.17.1"
+    "grunt-contrib-jshint": "~0.11.3",
+    "grunt-contrib-watch": "~0.6.1",
+    "grunt-mocha-test": "~0.12.7",
+    "mocha": "~2.3.3"
   },
   "dependencies": {
-    "JSONStream": "~0.8.0",
+    "JSONStream": "~1.0.6",
     "ledger-cli": "0.1.1",
-    "lodash": "~2.4.1",
-    "restify": "~2.6.1"
+    "lodash": "~3.10.1",
+    "restify": "~4.0.3"
   },
   "readmeFilename": "README.md"
 }


### PR DESCRIPTION
I experience node-gyp compilation errors on Mac OS 10.11 when npm tried to install restify. Updating the package versions solved the issue, so `npm install` now runs just fine.
