### PR TITLE
Upgrade npm modules

### DIFF
--- a/lib/ledger-rest.js
+++ b/lib/ledger-rest.js
@@ -4,46 +4,46 @@ var _ = require('lodash'),
     Version = require('./handlers/version').Version,
     Balance = require('./handlers/balance').Balance,
     Register = require('./handlers/register').Register;
-      
+
 var LedgerRest = (function() {
   var defaultConfig = {
     name: 'ledger-rest',
     debug: false
   };
-  
+
   function LedgerRest(options) {
     this.options = _.defaults({}, options, defaultConfig);
-    
+
     this.ledger = new Ledger(this.options);
-    
+
     this.createServer(this.options);
     this.configureRouting();
   }
-  
+
   LedgerRest.prototype.createServer = function(config) {
     this.server = restify.createServer({
       name: config.name
     });
-    
+
     this.server.use([
-      restify.acceptParser(this.server.acceptable),
-      restify.gzipResponse()
+      restify.plugins.acceptParser(this.server.acceptable),
+      restify.plugins.gzipResponse()
     ]);
   };
-  
+
   LedgerRest.prototype.listen = function(port, callback) {
     this.server.listen(port, function() {
       this.log('%s listening at %s', this.server.name, this.server.url);
-      
+
       if (callback) {
         callback();
       }
     }.bind(this));
   };
-  
+
   LedgerRest.prototype.close = function(callback) {
     this.log('%s is closing...', this.server.name);
-    
+
     this.server.close(function() {
       this.log('%s has closed', this.server.name);
       if (callback) {
@@ -51,24 +51,24 @@ var LedgerRest = (function() {
       }
     }.bind(this));
   };
-  
+
   LedgerRest.prototype.configureRouting = function() {
     var version = new Version(this.ledger),
         balance = new Balance(this.ledger),
         register = new Register(this.ledger);
-    
+
     this.server.get('/version', version.handle.bind(version));
     this.server.get('/balance', balance.handle.bind(balance));
     this.server.get('/register', register.handle.bind(register));
     this.server.get('/register/:account', register.handle.bind(register));
   };
-  
+
   LedgerRest.prototype.log = function() {
     if (this.options.debug) {
       console.log.apply(console, arguments);
     }
   };
-  
+
   return LedgerRest;
 })();
 

--- a/package.json
+++ b/package.json
@@ -32,13 +32,14 @@
     "grunt-contrib-jshint": "~1.0.0",
     "grunt-contrib-watch": "~0.6.1",
     "grunt-mocha-test": "~0.12.7",
-    "mocha": "~2.4.5"
+    "mocha": "~2.4.5",
+    "restify-clients": "^2.0.0"
   },
   "dependencies": {
-    "JSONStream": "~1.0.7",
-    "ledger-cli": "0.2.0",
-    "lodash": "~4.5.1",
-    "restify": "~4.0.4"
+    "JSONStream": "^1.3.2",
+    "ledger-cli": "^0.2.0",
+    "lodash": "^4.17.5",
+    "restify": "^6.3.4"
   },
   "readmeFilename": "README.md"
 }

--- a/spec/balance.spec.js
+++ b/spec/balance.spec.js
@@ -1,21 +1,21 @@
 var chai = require('chai'),
     expect = chai.expect,
-    restify = require('restify'),
+    restify = require('restify-clients'),
     LedgerRest = require('../lib/ledger-rest').LedgerRest;
 
 describe('Balance', function() {
   var spec, server, client;
-  
+
   // start ledger-rest server
   function startServer() {
     server = new LedgerRest({ file: 'spec/data/single-transaction.dat' });
     server.listen(3000);
   }
-  
+
   function stopServer(done) {
     server.close(done);
   }
-  
+
   // create JSON client
   function createClient() {
     client = restify.createJsonClient({
@@ -26,10 +26,10 @@ describe('Balance', function() {
       }
     });
   }
-  
+
   beforeEach(function() {
     spec = this;
-    
+
     startServer();
     createClient();
   });
@@ -37,10 +37,10 @@ describe('Balance', function() {
   afterEach(function(done) {
     stopServer(done);
   });
-  
+
   describe('single transaction', function() {
     var balances;
-    
+
     beforeEach(function(done) {
       client.get('/balance', function(err, req, res, obj) {
         if (err) {
@@ -56,7 +56,7 @@ describe('Balance', function() {
     it('should return balance for two accounts', function() {
       expect(balances.length).to.equal(2);
     });
-    
+
     it('should parse first balance', function() {
       expect(balances[0]).to.eql({
         total: {
@@ -71,7 +71,7 @@ describe('Balance', function() {
         }
       });
     });
-    
+
     it('should parse second balance', function() {
       expect(balances[1]).to.eql({
         total: {

--- a/spec/register.spec.js
+++ b/spec/register.spec.js
@@ -1,21 +1,21 @@
 var chai = require('chai'),
     expect = chai.expect,
-    restify = require('restify'),
+    restify = require('restify-clients'),
     LedgerRest = require('../lib/ledger-rest').LedgerRest;
 
 describe('Register', function() {
   var spec, server, client;
-  
+
   // start ledger-rest server
   function startServer() {
     server = new LedgerRest({ file: 'spec/data/drewr.dat' });
     server.listen(3000);
   }
-  
+
   function stopServer(done) {
     server.close(done);
   }
-  
+
   // create JSON client
   function createClient() {
     client = restify.createJsonClient({
@@ -26,10 +26,10 @@ describe('Register', function() {
       }
     });
   }
-  
+
   beforeEach(function() {
     spec = this;
-    
+
     startServer();
     createClient();
   });
@@ -37,10 +37,10 @@ describe('Register', function() {
   afterEach(function(done) {
     stopServer(done);
   });
-  
+
   describe('multiple transactions', function() {
     var entries;
-    
+
     beforeEach(function(done) {
       client.get('/register', function(err, req, res, obj) {
         if (err) {


### PR DESCRIPTION
Upgrade npm modules so `node-ledger-rest` can be run on newer Node.js
versions.

It also fixes this exception:

`TypeError: The super constructor to "inherits" must not be null or undefined`

Fixes #6 